### PR TITLE
Fixing the stream parameter in CopyTensors API and passing cudastream by value in createNotification API

### DIFF
--- a/onnxruntime/core/framework/plugin_data_transfer.cc
+++ b/onnxruntime/core/framework/plugin_data_transfer.cc
@@ -41,7 +41,7 @@ Status DataTransfer::CopyTensors(const std::vector<SrcDstPair>& src_dst_pairs) c
   for (size_t i = 0; i < src_dst_pairs.size(); ++i) {
     src_values.push_back(&values[i * 2]);
     dst_values.push_back(&values[i * 2 + 1]);
-    streams.push_back(nullptr);  // static_cast<OrtSyncStream*>(src_dst_pairs[i].src_stream));
+    streams.push_back(reinterpret_cast<OrtSyncStream*>(src_dst_pairs[i].src_stream));
   }
 
   auto* status = impl_.CopyTensors(&impl_, src_values.data(), dst_values.data(), streams.data(),

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_factory.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_provider_factory.cc
@@ -431,7 +431,7 @@ struct NvTrtRtxSyncNotificationImpl : OrtSyncNotificationImpl {
     Release = ReleaseImpl;
   }
 
-  cudaStream_t& stream_;
+  cudaStream_t stream_;
   cudaEvent_t event_;
 
   const OrtApi& ort_api;
@@ -477,9 +477,9 @@ struct NvTrtRtxSyncStreamImpl : OrtSyncStreamImpl {
     *notification_impl = nullptr;
 
     std::unique_ptr<NvTrtRtxSyncNotificationImpl> notification;
-    cudaStream_t* cuda_stream = static_cast<cudaStream_t*>(impl.stream_.GetHandle());
+    cudaStream_t cuda_stream = static_cast<cudaStream_t>(impl.stream_.GetHandle());
 
-    RETURN_IF_ERROR(NvTrtRtxSyncNotificationImpl::Create(*cuda_stream, impl.ort_api, notification));
+    RETURN_IF_ERROR(NvTrtRtxSyncNotificationImpl::Create(cuda_stream, impl.ort_api, notification));
     *notification_impl = notification.release();
 
     return nullptr;


### PR DESCRIPTION
Fixing the stream parameter in CopyTensors API and passing cudastream by value in createNotification API

### Description
<!-- Describe your changes. -->
Fixing the stream parameter in CopyTensors API to pass teh application passed stream instead of nullptr Passing cudastream by value in createNotification API as passing pointer was leading to dangling reference issues.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Without this code, copy tensors always happens synchronously even when app specifies a different stream to it.
- Passing pointer for cudastream in EP API is leading to dangling reference issues, hence switched to passing value.

